### PR TITLE
Add team assignment, slip submission, and phase transitions

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import Fastify from "fastify";
 import websocket from "@fastify/websocket";
 import { RoomManager } from "./roomManager.js";
-import { ServerMessageType } from "@fishbowl/shared";
+import { ServerMessageType, type ClientMessage } from "@fishbowl/shared";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 
@@ -27,6 +27,24 @@ app.get("/ws", { websocket: true }, (socket, req) => {
     socket.close(1008, error);
     return;
   }
+
+  socket.on("message", (data: Buffer | string) => {
+    try {
+      const msg: ClientMessage = JSON.parse(
+        typeof data === "string" ? data : data.toString()
+      );
+      const err = roomManager.handleMessage(socket, msg);
+      if (err) {
+        socket.send(
+          JSON.stringify({ type: ServerMessageType.Error, message: err })
+        );
+      }
+    } catch {
+      socket.send(
+        JSON.stringify({ type: ServerMessageType.Error, message: "Invalid message format" })
+      );
+    }
+  });
 
   socket.on("close", () => {
     roomManager.handleDisconnect(socket);

--- a/server/src/roomManager.test.ts
+++ b/server/src/roomManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { RoomManager } from "./roomManager.js";
-import { GamePhase, ServerMessageType } from "@fishbowl/shared";
+import { GamePhase, ServerMessageType, ClientMessageType, Team } from "@fishbowl/shared";
 
 /** Create a mock WebSocket */
 function mockWs(): any {
@@ -181,6 +181,286 @@ describe("RoomManager", () => {
       const ws = mockWs();
       // Should not throw
       rm.handleDisconnect(ws);
+    });
+  });
+
+  describe("assign-team", () => {
+    it("host can assign a player to a team", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      const room = rm.getRoom("AB12")!;
+      const bobId = room.players[1].id;
+
+      ws1.send.mockClear();
+      ws2.send.mockClear();
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.AssignTeam,
+        playerId: bobId,
+        team: Team.B,
+      });
+
+      expect(err).toBeNull();
+      expect(room.players[1].team).toBe(Team.B);
+
+      // Both clients should receive teams-updated
+      const msg1 = JSON.parse(ws1.send.mock.calls[0][0]);
+      expect(msg1.type).toBe(ServerMessageType.TeamsUpdated);
+      expect(msg1.players[1].team).toBe(Team.B);
+
+      const msg2 = JSON.parse(ws2.send.mock.calls[0][0]);
+      expect(msg2.type).toBe(ServerMessageType.TeamsUpdated);
+    });
+
+    it("non-host cannot assign teams", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      const room = rm.getRoom("AB12")!;
+      const aliceId = room.players[0].id;
+
+      const err = rm.handleMessage(ws2, {
+        type: ClientMessageType.AssignTeam,
+        playerId: aliceId,
+        team: Team.A,
+      });
+
+      expect(err).toBe("Only the host can assign teams");
+    });
+
+    it("rejects assigning a non-existent player", () => {
+      const ws1 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.AssignTeam,
+        playerId: "nonexistent-id",
+        team: Team.A,
+      });
+
+      expect(err).toBe("Player not found");
+    });
+  });
+
+  describe("randomize-teams", () => {
+    it("host can randomize teams and all players get assigned", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      const ws3 = mockWs();
+      const ws4 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+      rm.handleConnection(ws3, "AB12", "Carol");
+      rm.handleConnection(ws4, "AB12", "Dave");
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.RandomizeTeams,
+      });
+
+      expect(err).toBeNull();
+
+      const room = rm.getRoom("AB12")!;
+      // All players should have a team assigned
+      expect(room.players.every((p) => p.team !== null)).toBe(true);
+
+      // Teams should be evenly split (2 and 2 for 4 players)
+      const teamA = room.players.filter((p) => p.team === Team.A);
+      const teamB = room.players.filter((p) => p.team === Team.B);
+      expect(teamA.length).toBe(2);
+      expect(teamB.length).toBe(2);
+    });
+
+    it("handles odd number of players (extra goes to Team A)", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      const ws3 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+      rm.handleConnection(ws3, "AB12", "Carol");
+
+      rm.handleMessage(ws1, { type: ClientMessageType.RandomizeTeams });
+
+      const room = rm.getRoom("AB12")!;
+      const teamA = room.players.filter((p) => p.team === Team.A);
+      const teamB = room.players.filter((p) => p.team === Team.B);
+      expect(teamA.length).toBe(2);
+      expect(teamB.length).toBe(1);
+    });
+
+    it("non-host cannot randomize teams", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      const err = rm.handleMessage(ws2, {
+        type: ClientMessageType.RandomizeTeams,
+      });
+
+      expect(err).toBe("Only the host can randomize teams");
+    });
+
+    it("broadcasts teams-updated to all clients", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+      ws1.send.mockClear();
+      ws2.send.mockClear();
+
+      rm.handleMessage(ws1, { type: ClientMessageType.RandomizeTeams });
+
+      const msg1 = JSON.parse(ws1.send.mock.calls[0][0]);
+      const msg2 = JSON.parse(ws2.send.mock.calls[0][0]);
+      expect(msg1.type).toBe(ServerMessageType.TeamsUpdated);
+      expect(msg2.type).toBe(ServerMessageType.TeamsUpdated);
+    });
+  });
+
+  describe("submit-slips", () => {
+    function setupSubmittingRoom() {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      // Manually set phase to submitting
+      const room = rm.getRoom("AB12")!;
+      room.phase = GamePhase.Submitting;
+
+      return { ws1, ws2, room };
+    }
+
+    it("player can submit exactly 4 slips", () => {
+      const { ws1, room } = setupSubmittingRoom();
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["Beyoncé", "Einstein", "Pikachu", "Cleopatra"],
+      });
+
+      expect(err).toBeNull();
+      expect(room.players[0].slips).toHaveLength(4);
+      expect(room.players[0].slips[0].text).toBe("Beyoncé");
+      expect(room.players[0].slips[0].submittedBy).toBe(room.players[0].id);
+    });
+
+    it("rejects fewer than 4 slips", () => {
+      const { ws1 } = setupSubmittingRoom();
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["One", "Two", "Three"],
+      });
+
+      expect(err).toBe("Must submit exactly 4 slips");
+    });
+
+    it("rejects more than 4 slips", () => {
+      const { ws1 } = setupSubmittingRoom();
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["One", "Two", "Three", "Four", "Five"],
+      });
+
+      expect(err).toBe("Must submit exactly 4 slips");
+    });
+
+    it("rejects empty slip text", () => {
+      const { ws1 } = setupSubmittingRoom();
+
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["Beyoncé", "", "Pikachu", "Cleopatra"],
+      });
+
+      expect(err).toBe("All slips must be non-empty");
+    });
+
+    it("rejects submission when not in submitting phase", () => {
+      const ws1 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+
+      // Room is in lobby phase by default
+      const err = rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["One", "Two", "Three", "Four"],
+      });
+
+      expect(err).toBe("Not in submitting phase");
+    });
+  });
+
+  describe("phase transition: submitting → playing", () => {
+    it("transitions to playing when all players have submitted slips", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      const room = rm.getRoom("AB12")!;
+      room.phase = GamePhase.Submitting;
+
+      // Alice submits
+      rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["Slip1", "Slip2", "Slip3", "Slip4"],
+      });
+      expect(room.phase).toBe(GamePhase.Submitting);
+
+      ws1.send.mockClear();
+      ws2.send.mockClear();
+
+      // Bob submits — should trigger transition
+      rm.handleMessage(ws2, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["Slip5", "Slip6", "Slip7", "Slip8"],
+      });
+
+      expect(room.phase).toBe(GamePhase.Playing);
+
+      // Slip pool should contain all 8 slips
+      expect(room.slipPool).toHaveLength(8);
+
+      // Should have received phase-changed message
+      const allMsgs1 = ws1.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+      const phaseMsg1 = allMsgs1.find(
+        (m: any) => m.type === ServerMessageType.PhaseChanged
+      );
+      expect(phaseMsg1).toBeDefined();
+      expect(phaseMsg1.phase).toBe(GamePhase.Playing);
+
+      const allMsgs2 = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+      const phaseMsg2 = allMsgs2.find(
+        (m: any) => m.type === ServerMessageType.PhaseChanged
+      );
+      expect(phaseMsg2).toBeDefined();
+      expect(phaseMsg2.phase).toBe(GamePhase.Playing);
+    });
+
+    it("does not transition if not all players have submitted", () => {
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice");
+      rm.handleConnection(ws2, "AB12", "Bob");
+
+      const room = rm.getRoom("AB12")!;
+      room.phase = GamePhase.Submitting;
+
+      // Only Alice submits
+      rm.handleMessage(ws1, {
+        type: ClientMessageType.SubmitSlips,
+        texts: ["Slip1", "Slip2", "Slip3", "Slip4"],
+      });
+
+      expect(room.phase).toBe(GamePhase.Submitting);
+      expect(room.slipPool).toHaveLength(0);
     });
   });
 });

--- a/server/src/roomManager.ts
+++ b/server/src/roomManager.ts
@@ -3,11 +3,14 @@ import type { WebSocket } from "ws";
 import {
   type Room,
   type Player,
+  type Slip,
   type ServerMessage,
+  type ClientMessage,
   GamePhase,
   Team,
   RoundType,
   ServerMessageType,
+  ClientMessageType,
 } from "@fishbowl/shared";
 
 /** A connected client: the WebSocket plus player/room identity */
@@ -140,15 +143,7 @@ export class RoomManager {
    * Removes them from the room, transfers host if needed.
    */
   handleDisconnect(ws: WebSocket): void {
-    // Find the client by WebSocket reference
-    let clientEntry: ConnectedClient | undefined;
-    for (const [, client] of this.clients) {
-      if (client.ws === ws) {
-        clientEntry = client;
-        break;
-      }
-    }
-
+    const clientEntry = this.findClientByWs(ws);
     if (!clientEntry) return;
 
     const { playerId, roomCode } = clientEntry;
@@ -185,9 +180,145 @@ export class RoomManager {
     this.broadcastRoomState(roomCode);
   }
 
+  /**
+   * Handle an incoming client message on an established connection.
+   * Returns an error string if the message is invalid, or null on success.
+   */
+  handleMessage(ws: WebSocket, message: ClientMessage): string | null {
+    const client = this.findClientByWs(ws);
+    if (!client) return "Not connected to a room";
+
+    const room = this.rooms.get(client.roomCode);
+    if (!room) return "Room not found";
+
+    const player = room.players.find((p) => p.id === client.playerId);
+    if (!player) return "Player not found in room";
+
+    switch (message.type) {
+      case ClientMessageType.AssignTeam:
+        return this.handleAssignTeam(room, player, message.playerId, message.team);
+      case ClientMessageType.RandomizeTeams:
+        return this.handleRandomizeTeams(room, player);
+      case ClientMessageType.SubmitSlips:
+        return this.handleSubmitSlips(room, player, message.texts);
+      default:
+        return `Unhandled message type: ${message.type}`;
+    }
+  }
+
+  private handleAssignTeam(room: Room, sender: Player, targetPlayerId: string, team: Team): string | null {
+    if (!sender.isHost) return "Only the host can assign teams";
+
+    const target = room.players.find((p) => p.id === targetPlayerId);
+    if (!target) return "Player not found";
+
+    target.team = team;
+    room.lastActivityAt = Date.now();
+
+    this.broadcastTeamsUpdated(room);
+    return null;
+  }
+
+  private handleRandomizeTeams(room: Room, sender: Player): string | null {
+    if (!sender.isHost) return "Only the host can randomize teams";
+
+    // Shuffle players array copy using Fisher-Yates
+    const shuffled = [...room.players];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+
+    // Split evenly: first half Team A, second half Team B
+    const half = Math.ceil(shuffled.length / 2);
+    for (let i = 0; i < shuffled.length; i++) {
+      shuffled[i].team = i < half ? Team.A : Team.B;
+    }
+
+    room.lastActivityAt = Date.now();
+    this.broadcastTeamsUpdated(room);
+    return null;
+  }
+
+  private handleSubmitSlips(room: Room, player: Player, texts: string[]): string | null {
+    if (room.phase !== GamePhase.Submitting) return "Not in submitting phase";
+
+    if (!Array.isArray(texts) || texts.length !== 4) {
+      return "Must submit exactly 4 slips";
+    }
+
+    // Validate each slip text is non-empty
+    const trimmed = texts.map((t) => (typeof t === "string" ? t.trim() : ""));
+    if (trimmed.some((t) => !t)) {
+      return "All slips must be non-empty";
+    }
+
+    // Create slip objects
+    const slips: Slip[] = trimmed.map((text) => ({
+      id: uuidv4(),
+      text,
+      submittedBy: player.id,
+    }));
+
+    player.slips = slips;
+    room.lastActivityAt = Date.now();
+
+    // Broadcast updated room state so all clients see slip submission progress
+    this.broadcastRoomState(room.code);
+
+    // Check if all players have submitted — transition to playing
+    const allSubmitted = room.players.every((p) => p.slips.length === 4);
+    if (allSubmitted) {
+      room.phase = GamePhase.Playing;
+
+      // Collect all slips into the pool
+      room.slipPool = room.players.flatMap((p) => [...p.slips]);
+
+      this.broadcastPhaseChanged(room);
+      this.broadcastRoomState(room.code);
+    }
+
+    return null;
+  }
+
+  private broadcastTeamsUpdated(room: Room): void {
+    const message: ServerMessage = {
+      type: ServerMessageType.TeamsUpdated,
+      players: room.players,
+    };
+    for (const client of this.getClientsInRoom(room.code)) {
+      this.send(client.ws, message);
+    }
+  }
+
+  private broadcastPhaseChanged(room: Room): void {
+    const message: ServerMessage = {
+      type: ServerMessageType.PhaseChanged,
+      phase: room.phase,
+      round: room.round,
+      roundNumber: room.roundNumber,
+    };
+    for (const client of this.getClientsInRoom(room.code)) {
+      this.send(client.ws, message);
+    }
+  }
+
+  /** Find a connected client by WebSocket reference */
+  private findClientByWs(ws: WebSocket): ConnectedClient | undefined {
+    for (const [, client] of this.clients) {
+      if (client.ws === ws) return client;
+    }
+    return undefined;
+  }
+
   /** Get a room by code (for testing) */
   getRoom(code: string): Room | undefined {
     return this.rooms.get(code);
+  }
+
+  /** Find a client by player ID (for testing) */
+  getClient(playerId: string): ConnectedClient | undefined {
+    return this.clients.get(playerId);
   }
 
   /** Get all clients in a room */


### PR DESCRIPTION
## Summary
- **assign-team**: Host can send `assign-team` to move any player to Team A or Team B; all clients receive `teams-updated`
- **randomize-teams**: Host can send `randomize-teams` to evenly shuffle players into teams; all clients receive `teams-updated`
- **submit-slips**: Players can submit exactly 4 slip names with server-side validation (count, non-empty text)
- **Phase transition**: When all players have submitted slips, game phase auto-transitions from `submitting` → `playing` and all clients receive `phase-changed`
- **WebSocket message routing**: Wired up `socket.on("message")` in `index.ts` to parse and route `ClientMessage` types to `RoomManager.handleMessage()`

## Test plan
- [x] 27 unit tests covering all four operations and edge cases
- [x] Host-only permission checks for assign-team and randomize-teams
- [x] Slip validation (exactly 4, non-empty)
- [x] Phase transition only fires when ALL players have submitted
- [x] `npm run build` passes
- [x] `npm run test` passes (54 tests across source + compiled)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)