### PR TITLE
Add round progression, game-over, and new-game reset

### DIFF
--- a/server/src/roomManager.test.ts
+++ b/server/src/roomManager.test.ts
@@ -502,6 +502,7 @@ describe("RoomManager", () => {
         { id: "s8", text: "Gandalf", submittedBy: room.players[3].id },
       ];
       room.slipPool = [...slips];
+      room.allSlips = [...slips];
       room.activeTeam = Team.A;
 
       // Clear all mock calls from setup
@@ -734,20 +735,23 @@ describe("RoomManager", () => {
     });
 
     describe("turn-end conditions", () => {
-      it("turn ends when all slips in pool are guessed (pool empty)", () => {
+      it("turn ends and round ends when all slips in pool are guessed (pool empty)", () => {
         const { ws1, room } = setupPlayingRoom();
         // Small pool: 2 slips
         room.slipPool = [
           { id: "s1", text: "Einstein", submittedBy: "p1" },
           { id: "s2", text: "Beyoncé", submittedBy: "p1" },
         ];
+        room.allSlips = [...room.slipPool];
 
         rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
         rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s1
         rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s2
 
-        expect(room.phase).toBe(GamePhase.TurnEnd);
-        expect(room.slipPool).toHaveLength(0);
+        // Pool empty triggers round end (round 1 → round 2)
+        expect(room.phase).toBe(GamePhase.RoundEnd);
+        // Pool reshuffled with all slips
+        expect(room.slipPool).toHaveLength(2);
         expect(room.scores[Team.A]).toBe(2);
       });
 
@@ -773,19 +777,20 @@ describe("RoomManager", () => {
 
       it("turn-ended message includes correct guessedCount and scores", () => {
         const { ws1, ws2, room } = setupPlayingRoom();
-        room.slipPool = [
-          { id: "s1", text: "Einstein", submittedBy: "p1" },
-          { id: "s2", text: "Beyoncé", submittedBy: "p1" },
-        ];
+        // 8 slips in pool (from setupPlayingRoom), guess 2 then let timer expire
 
         rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s1
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s2
+
         ws1.send.mockClear();
         ws2.send.mockClear();
 
-        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s1
-        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s2 → pool empty → turn ends
+        // Let timer expire to end the turn normally (pool still has 6 slips)
+        vi.advanceTimersByTime(30_000);
 
-        // Find TurnEnded in ws2 messages (non-clue-giver to avoid extra messages)
+        // Find TurnEnded in ws2 messages
         const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
         const turnEnded = allMsgs.find(
           (m: any) => m.type === ServerMessageType.TurnEnded
@@ -832,5 +837,361 @@ describe("RoomManager", () => {
         expect(room.activeClueGiverId).toBe(carolId);
       });
     });
+
+    // -------------------------------------------------------------------------
+    // Round Progression & Game Over
+    // -------------------------------------------------------------------------
+
+    describe("round progression", () => {
+      it("round ends when slip pool is empty, advancing describe → charades", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        ws1.send.mockClear();
+        ws2.send.mockClear();
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // pool empty
+
+        expect(room.phase).toBe(GamePhase.RoundEnd);
+        expect(room.roundNumber).toBe(2);
+        expect(room.round).toBe("charades");
+
+        // Pool reshuffled with all slips
+        expect(room.slipPool).toHaveLength(1);
+
+        // round-ended message sent
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const roundEnded = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.RoundEnded
+        );
+        expect(roundEnded).toBeDefined();
+        expect(roundEnded.completedRound).toBe("describe");
+        expect(roundEnded.nextRound).toBe("charades");
+        expect(roundEnded.scores).toBeDefined();
+      });
+
+      it("advances charades → one-word", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.round = "charades" as any;
+        room.roundNumber = 2;
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        expect(room.phase).toBe(GamePhase.RoundEnd);
+        expect(room.roundNumber).toBe(3);
+        expect(room.round).toBe("one-word");
+      });
+
+      it("all slips return to pool and are reshuffled between rounds", () => {
+        const { ws1, room } = setupPlayingRoom();
+        const allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+          { id: "s2", text: "Beyoncé", submittedBy: "p1" },
+          { id: "s3", text: "Pikachu", submittedBy: "p1" },
+        ];
+        room.slipPool = [...allSlips];
+        room.allSlips = [...allSlips];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+
+        // Guess all slips to empty the pool
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s1
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s2
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // s3
+
+        // All slips back in pool
+        expect(room.slipPool).toHaveLength(3);
+        const poolIds = room.slipPool.map((s) => s.id).sort();
+        expect(poolIds).toEqual(["s1", "s2", "s3"]);
+      });
+
+      it("host can start turn from round-end phase", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // round end
+
+        expect(room.phase).toBe(GamePhase.RoundEnd);
+
+        // Start turn in the new round
+        ws1.send.mockClear();
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(err).toBeNull();
+        expect(room.phase).toBe(GamePhase.TurnActive);
+      });
+
+      it("does not switch active team when round ends (carryover team goes first)", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.activeTeam = Team.A;
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // round end
+
+        // Team A should still be active (they get carryover turn)
+        expect(room.activeTeam).toBe(Team.A);
+      });
+    });
+
+    describe("carryover time", () => {
+      it("carryover time is awarded when last slip guessed mid-turn", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        // Timer starts at 30. Advance 10 seconds, leaving 20.
+        vi.advanceTimersByTime(10_000);
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        expect(room.carryoverTime).toBe(20);
+      });
+
+      it("turn-ended message includes carryoverTime when round ends mid-turn", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        vi.advanceTimersByTime(5_000); // 25 seconds remaining
+        ws2.send.mockClear();
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const turnEnded = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.TurnEnded
+        );
+        expect(turnEnded).toBeDefined();
+        expect(turnEnded.carryoverTime).toBe(25);
+      });
+
+      it("carryover time is used as turn duration for the next turn in new round", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        vi.advanceTimersByTime(15_000); // 15 seconds remaining
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt }); // round end
+
+        expect(room.carryoverTime).toBe(15);
+
+        // Start next turn — should use carryover time
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(room.turnTimeRemaining).toBe(15);
+        expect(room.carryoverTime).toBe(0); // consumed
+      });
+
+      it("no carryover when round ends with timer at 0", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        vi.advanceTimersByTime(29_000); // 1 second remaining
+        room.turnTimeRemaining = 0; // simulate exact 0
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        expect(room.carryoverTime).toBe(0);
+      });
+    });
+
+    describe("game over", () => {
+      it("game over after round 3 ends", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.round = "one-word" as any;
+        room.roundNumber = 3;
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        ws2.send.mockClear();
+
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        expect(room.phase).toBe(GamePhase.GameOver);
+
+        // Check messages
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+
+        const roundEnded = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.RoundEnded
+        );
+        expect(roundEnded).toBeDefined();
+        expect(roundEnded.completedRound).toBe("one-word");
+        expect(roundEnded.nextRound).toBeUndefined();
+
+        const gameOver = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.GameOver
+        );
+        expect(gameOver).toBeDefined();
+        expect(gameOver.scores[Team.A]).toBe(1);
+        expect(gameOver.winner).toBe(Team.A);
+      });
+
+      it("game-over message shows correct winner (Team B)", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.round = "one-word" as any;
+        room.roundNumber = 3;
+        room.scores = { [Team.A]: 3, [Team.B]: 5 };
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        ws2.send.mockClear();
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const gameOver = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.GameOver
+        );
+        expect(gameOver.winner).toBe(Team.B);
+      });
+
+      it("game-over message shows tie when scores are equal", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.round = "one-word" as any;
+        room.roundNumber = 3;
+        room.scores = { [Team.A]: 5, [Team.B]: 5 };
+        room.slipPool = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        room.allSlips = [
+          { id: "s1", text: "Einstein", submittedBy: "p1" },
+        ];
+        // Team A active, guessing adds +1 to Team A making it 6-5
+        // To get a tie: set A=4, B=5, then A guesses 1 making it 5-5
+        room.scores = { [Team.A]: 4, [Team.B]: 5 };
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        ws2.send.mockClear();
+        rm.handleMessage(ws1, { type: ClientMessageType.GotIt });
+
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const gameOver = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.GameOver
+        );
+        expect(gameOver.scores[Team.A]).toBe(5);
+        expect(gameOver.scores[Team.B]).toBe(5);
+        expect(gameOver.winner).toBe("tie");
+      });
+
+      it("cannot start turn after game over", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.phase = GamePhase.GameOver;
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(err).toBe("Cannot start a turn in current phase");
+      });
+    });
+
+    describe("new-game", () => {
+      it("host can start new game after game over, resetting to submitting phase", () => {
+        const { ws1, ws2, room } = setupPlayingRoom();
+        room.phase = GamePhase.GameOver;
+        room.scores = { [Team.A]: 10, [Team.B]: 7 };
+        room.roundNumber = 3;
+        room.round = "one-word" as any;
+
+        ws1.send.mockClear();
+        ws2.send.mockClear();
+
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.NewGame });
+        expect(err).toBeNull();
+
+        expect(room.phase).toBe(GamePhase.Submitting);
+        expect(room.round).toBe("describe");
+        expect(room.roundNumber).toBe(1);
+        expect(room.scores[Team.A]).toBe(0);
+        expect(room.scores[Team.B]).toBe(0);
+        expect(room.slipPool).toHaveLength(0);
+        expect(room.allSlips).toHaveLength(0);
+        expect(room.carryoverTime).toBe(0);
+
+        // Player slips cleared
+        for (const p of room.players) {
+          expect(p.slips).toHaveLength(0);
+        }
+
+        // Players still in room with teams intact
+        expect(room.players).toHaveLength(4);
+
+        // Phase-changed and room-state broadcasts sent
+        const allMsgs = ws2.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const phaseMsg = allMsgs.find(
+          (m: any) => m.type === ServerMessageType.PhaseChanged
+        );
+        expect(phaseMsg).toBeDefined();
+        expect(phaseMsg.phase).toBe(GamePhase.Submitting);
+      });
+
+      it("non-host cannot start new game", () => {
+        const { ws2, room } = setupPlayingRoom();
+        room.phase = GamePhase.GameOver;
+
+        const err = rm.handleMessage(ws2, { type: ClientMessageType.NewGame });
+        expect(err).toBe("Only the host can start a new game");
+      });
+
+      it("cannot start new game unless in game-over phase", () => {
+        const { ws1, room } = setupPlayingRoom();
+        room.phase = GamePhase.Playing;
+
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.NewGame });
+        expect(err).toBe("Can only start a new game after game over");
+      });
+    });
   });
 });
+

--- a/server/src/roomManager.ts
+++ b/server/src/roomManager.ts
@@ -49,6 +49,8 @@ function makeDefaultRoom(code: string): Room {
     turnTimeRemaining: 0,
     turnGuessed: [],
     turnSkipped: [],
+    allSlips: [],
+    carryoverTime: 0,
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
   };
@@ -209,6 +211,8 @@ export class RoomManager {
         return this.handleGotIt(room, player);
       case ClientMessageType.Skip:
         return this.handleSkip(room, player);
+      case ClientMessageType.NewGame:
+        return this.handleNewGame(room, player);
       default:
         return `Unhandled message type: ${message.type}`;
     }
@@ -279,8 +283,9 @@ export class RoomManager {
     if (allSubmitted) {
       room.phase = GamePhase.Playing;
 
-      // Collect all slips into the pool
-      room.slipPool = room.players.flatMap((p) => [...p.slips]);
+      // Collect all slips into the pool and save master list for reshuffling
+      room.allSlips = room.players.flatMap((p) => [...p.slips]);
+      room.slipPool = [...room.allSlips];
 
       this.broadcastPhaseChanged(room);
       this.broadcastRoomState(room.code);
@@ -295,7 +300,11 @@ export class RoomManager {
 
   private handleStartTurn(room: Room, player: Player): string | null {
     if (!player.isHost) return "Only the host can start a turn";
-    if (room.phase !== GamePhase.Playing && room.phase !== GamePhase.TurnEnd) {
+    if (
+      room.phase !== GamePhase.Playing &&
+      room.phase !== GamePhase.TurnEnd &&
+      room.phase !== GamePhase.RoundEnd
+    ) {
       return "Cannot start a turn in current phase";
     }
     if (room.slipPool.length === 0) return "No slips in the pool";
@@ -309,7 +318,10 @@ export class RoomManager {
 
     room.activeClueGiverId = clueGiver.id;
     room.phase = GamePhase.TurnActive;
-    room.turnTimeRemaining = 30;
+
+    // Apply carryover time if available, otherwise 30 seconds
+    room.turnTimeRemaining = room.carryoverTime > 0 ? room.carryoverTime : 30;
+    room.carryoverTime = 0;
     room.turnGuessed = [];
     room.turnSkipped = [];
 
@@ -412,6 +424,39 @@ export class RoomManager {
     return null;
   }
 
+  private handleNewGame(room: Room, player: Player): string | null {
+    if (!player.isHost) return "Only the host can start a new game";
+    if (room.phase !== GamePhase.GameOver) {
+      return "Can only start a new game after game over";
+    }
+
+    // Reset game state, keep players and teams
+    room.phase = GamePhase.Submitting;
+    room.round = RoundType.Describe;
+    room.roundNumber = 1;
+    room.scores = { [Team.A]: 0, [Team.B]: 0 };
+    room.activeTeam = Team.A;
+    room.clueGiverIndex = { [Team.A]: 0, [Team.B]: 0 };
+    room.activeClueGiverId = null;
+    room.slipPool = [];
+    room.allSlips = [];
+    room.currentSlip = null;
+    room.turnTimeRemaining = 0;
+    room.turnGuessed = [];
+    room.turnSkipped = [];
+    room.carryoverTime = 0;
+
+    // Clear player slips so they can submit new ones
+    for (const p of room.players) {
+      p.slips = [];
+    }
+
+    room.lastActivityAt = Date.now();
+    this.broadcastPhaseChanged(room);
+    this.broadcastRoomState(room.code);
+    return null;
+  }
+
   /** Draw the next unskipped slip from the pool */
   private drawNextSlip(room: Room): void {
     const available = room.slipPool.filter(
@@ -461,35 +506,94 @@ export class RoomManager {
     }
   }
 
-  /** End the current turn */
+  /** End the current turn, handling round transitions and game over */
   private endTurn(room: Room): void {
     this.clearTurnTimer(room.code);
-
-    room.phase = GamePhase.TurnEnd;
     room.currentSlip = null;
 
-    // Advance clue-giver index for the active team
-    const teamPlayers = room.players.filter((p) => p.team === room.activeTeam);
-    if (teamPlayers.length > 0) {
-      room.clueGiverIndex[room.activeTeam] =
-        (room.clueGiverIndex[room.activeTeam] + 1) % teamPlayers.length;
-    }
-
-    // Switch active team
-    room.activeTeam = room.activeTeam === Team.A ? Team.B : Team.A;
-    room.activeClueGiverId = null;
-    room.turnTimeRemaining = 0;
+    const poolEmpty = room.slipPool.length === 0;
+    const carryover = poolEmpty ? room.turnTimeRemaining : 0;
 
     // Broadcast turn-ended
     this.broadcastToRoom(room.code, {
       type: ServerMessageType.TurnEnded,
       guessedCount: room.turnGuessed.length,
       scores: { ...room.scores },
+      ...(carryover > 0 ? { carryoverTime: carryover } : {}),
     });
 
     room.turnGuessed = [];
     room.turnSkipped = [];
     room.lastActivityAt = Date.now();
+
+    if (poolEmpty) {
+      // Round ended — all slips guessed
+      const completedRound = room.round;
+
+      if (room.roundNumber >= 3) {
+        // Game over
+        room.phase = GamePhase.GameOver;
+        room.activeClueGiverId = null;
+        room.turnTimeRemaining = 0;
+
+        this.broadcastToRoom(room.code, {
+          type: ServerMessageType.RoundEnded,
+          completedRound,
+          scores: { ...room.scores },
+        });
+
+        const winner: Team | "tie" =
+          room.scores[Team.A] > room.scores[Team.B]
+            ? Team.A
+            : room.scores[Team.B] > room.scores[Team.A]
+              ? Team.B
+              : "tie";
+
+        this.broadcastToRoom(room.code, {
+          type: ServerMessageType.GameOver,
+          scores: { ...room.scores },
+          winner,
+        });
+      } else {
+        // Advance to next round
+        const nextRound =
+          room.roundNumber === 1 ? RoundType.Charades : RoundType.OneWord;
+        room.roundNumber += 1;
+        room.round = nextRound;
+        room.phase = GamePhase.RoundEnd;
+        room.carryoverTime = carryover;
+        // Don't switch team or advance clue-giver — carryover turn
+        room.activeClueGiverId = null;
+        room.turnTimeRemaining = 0;
+
+        // Reshuffle all slips back into pool
+        room.slipPool = [...room.allSlips].sort(() => Math.random() - 0.5);
+
+        this.broadcastToRoom(room.code, {
+          type: ServerMessageType.RoundEnded,
+          completedRound,
+          scores: { ...room.scores },
+          nextRound,
+        });
+      }
+    } else {
+      // Normal turn end — pool still has slips
+      room.phase = GamePhase.TurnEnd;
+
+      // Advance clue-giver index for the active team
+      const teamPlayers = room.players.filter(
+        (p) => p.team === room.activeTeam,
+      );
+      if (teamPlayers.length > 0) {
+        room.clueGiverIndex[room.activeTeam] =
+          (room.clueGiverIndex[room.activeTeam] + 1) % teamPlayers.length;
+      }
+
+      // Switch active team
+      room.activeTeam = room.activeTeam === Team.A ? Team.B : Team.A;
+      room.activeClueGiverId = null;
+      room.turnTimeRemaining = 0;
+    }
   }
 
   /** Broadcast a message to all clients in a room */

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -71,6 +71,10 @@ export interface Room {
   turnGuessed: Slip[];
   /** Slip IDs skipped during the current turn (cannot re-skip) */
   turnSkipped: string[];
+  /** Master list of all slips (used to reshuffle between rounds) */
+  allSlips: Slip[];
+  /** Seconds carried over from the previous round's last turn */
+  carryoverTime: number;
   createdAt: number;
   lastActivityAt: number;
 }


### PR DESCRIPTION
## Summary
- Round transitions: describe → charades → one-word → game-over with slip pool reshuffling between rounds
- Carryover time: when the last slip is guessed mid-turn, remaining seconds carry to the same team's next turn in the new round
- Game over: after round 3 ends, broadcasts `game-over` with final scores and winner (or tie)
- New game: host sends `new-game` to reset slips and return to `submitting` phase with same players
- Added `allSlips` and `carryoverTime` fields to the `Room` interface

## Test plan
- [x] Round ends when slip pool empties, advancing describe → charades → one-word
- [x] All slips return to pool and are reshuffled between rounds
- [x] Active team does not switch on round end (carryover team goes first)
- [x] Carryover time awarded when last slip guessed mid-turn
- [x] Carryover time used as turn duration for next turn in new round
- [x] No carryover when timer is at 0
- [x] Game over after round 3 with correct winner/tie determination
- [x] Cannot start turn after game over
- [x] New-game resets to submitting phase, clears slips, zeroes scores
- [x] Non-host cannot start new game; must be in game-over phase
- [x] All 60 tests pass, build succeeds

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)