### PR TITLE
Add configurable ports for server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ npm run dev:client
 
 Open `http://localhost:5173` in your browser. The Vite dev server automatically proxies WebSocket connections to the game server on port 3000.
 
+### Custom Ports
+
+All ports are configurable via environment variables. The defaults are **3000** (server) and **5173** (client).
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `3000` | Game server port |
+| `VITE_SERVER_PORT` | `3000` | Tells the client which port the game server is on |
+| `VITE_CLIENT_PORT` | `5173` | Vite dev server port |
+
+When changing the server port, set both `PORT` and `VITE_SERVER_PORT` so the client knows where to connect:
+
+```bash
+# Terminal 1 — run server on port 4000
+PORT=4000 npm run dev:server
+
+# Terminal 2 — run client on port 8080, pointing at server port 4000
+VITE_SERVER_PORT=4000 VITE_CLIENT_PORT=8080 npm run dev:client
+```
+
 ## Production Build
 
 ```bash

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SERVER_PORT?: string;
+  readonly VITE_CLIENT_PORT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/client/src/ws.ts
+++ b/client/src/ws.ts
@@ -19,7 +19,9 @@ export class WsClient {
 
     const protocol = location.protocol === "https:" ? "wss:" : "ws:";
     const host = location.hostname;
-    const port = location.port === "5173" ? "3000" : location.port;
+    const serverPort = import.meta.env.VITE_SERVER_PORT ?? "3000";
+    const clientPort = import.meta.env.VITE_CLIENT_PORT ?? "5173";
+    const port = location.port === clientPort ? serverPort : location.port;
     const url = `${protocol}//${host}:${port}/ws?room=${encodeURIComponent(roomCode)}&name=${encodeURIComponent(playerName)}`;
 
     this.ws = new WebSocket(url);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite";
 import path from "path";
 
 export default defineConfig({
+  server: {
+    port: parseInt(process.env.VITE_CLIENT_PORT ?? "5173", 10),
+  },
   resolve: {
     alias: {
       "@fishbowl/shared": path.resolve(__dirname, "../shared/src/index.ts"),


### PR DESCRIPTION
## Summary
- Add `PORT` (server), `VITE_SERVER_PORT`, and `VITE_CLIENT_PORT` environment variables for configurable ports
- Update client WebSocket logic to use env vars instead of hardcoded port values
- Add Vite env type declarations (`vite-env.d.ts`)
- Document port override usage in README with examples

Closes #26

## Test plan
- [ ] Run `npm run build` — should pass with no errors
- [ ] Start server with default ports — works as before on 3000/5173
- [ ] Start server with custom ports (`PORT=4000 npm run dev:server`, `VITE_SERVER_PORT=4000 VITE_CLIENT_PORT=8080 npm run dev:client`) — client connects to correct server port

🤖 Generated with [Claude Code](https://claude.com/claude-code)