### PR TITLE
Add start-game handler for lobby-to-submitting transition

### DIFF
--- a/server/src/roomManager.test.ts
+++ b/server/src/roomManager.test.ts
@@ -1192,6 +1192,55 @@ describe("RoomManager", () => {
         expect(err).toBe("Can only start a new game after game over");
       });
     });
+
+    describe("start-game", () => {
+      it("host transitions room from Lobby to Submitting", () => {
+        const ws1 = mockWs();
+        const ws2 = mockWs();
+        rm.handleConnection(ws1, "AB12", "Alice");
+        rm.handleConnection(ws2, "AB12", "Bob");
+        const room = rm.getRoom("AB12")!;
+        expect(room.phase).toBe(GamePhase.Lobby);
+
+        ws1.send.mockClear();
+        ws2.send.mockClear();
+
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.StartGame });
+        expect(err).toBeNull();
+        expect(room.phase).toBe(GamePhase.Submitting);
+
+        // Both clients should receive a phase-changed broadcast
+        const msg1 = JSON.parse(ws1.send.mock.calls[0][0]);
+        expect(msg1.type).toBe(ServerMessageType.PhaseChanged);
+        expect(msg1.phase).toBe(GamePhase.Submitting);
+
+        const msg2 = JSON.parse(ws2.send.mock.calls[0][0]);
+        expect(msg2.type).toBe(ServerMessageType.PhaseChanged);
+        expect(msg2.phase).toBe(GamePhase.Submitting);
+      });
+
+      it("rejects start-game from non-host player", () => {
+        const ws1 = mockWs();
+        const ws2 = mockWs();
+        rm.handleConnection(ws1, "AB12", "Alice");
+        rm.handleConnection(ws2, "AB12", "Bob");
+        const room = rm.getRoom("AB12")!;
+
+        const err = rm.handleMessage(ws2, { type: ClientMessageType.StartGame });
+        expect(err).toBe("Only the host can start the game");
+        expect(room.phase).toBe(GamePhase.Lobby);
+      });
+
+      it("rejects start-game when not in Lobby phase", () => {
+        const ws1 = mockWs();
+        rm.handleConnection(ws1, "AB12", "Alice");
+        const room = rm.getRoom("AB12")!;
+        room.phase = GamePhase.Submitting;
+
+        const err = rm.handleMessage(ws1, { type: ClientMessageType.StartGame });
+        expect(err).toBe("Game can only be started from the lobby");
+      });
+    });
   });
 });
 

--- a/server/src/roomManager.ts
+++ b/server/src/roomManager.ts
@@ -203,6 +203,8 @@ export class RoomManager {
         return this.handleAssignTeam(room, player, message.playerId, message.team);
       case ClientMessageType.RandomizeTeams:
         return this.handleRandomizeTeams(room, player);
+      case ClientMessageType.StartGame:
+        return this.handleStartGame(room, player);
       case ClientMessageType.SubmitSlips:
         return this.handleSubmitSlips(room, player, message.texts);
       case ClientMessageType.StartTurn:
@@ -249,6 +251,16 @@ export class RoomManager {
 
     room.lastActivityAt = Date.now();
     this.broadcastTeamsUpdated(room);
+    return null;
+  }
+
+  private handleStartGame(room: Room, player: Player): string | null {
+    if (room.phase !== GamePhase.Lobby) return "Game can only be started from the lobby";
+    if (!player.isHost) return "Only the host can start the game";
+
+    room.phase = GamePhase.Submitting;
+    room.lastActivityAt = Date.now();
+    this.broadcastPhaseChanged(room);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Adds `case ClientMessageType.StartGame` to the message router in `roomManager.ts`
- Implements `handleStartGame()` that validates the sender is host and room is in Lobby phase, then transitions to Submitting and broadcasts `phase-changed`
- Adds 3 unit tests: happy path, non-host rejection, wrong-phase rejection

Closes #28

## Test plan
- [x] All 63 existing tests still pass
- [x] New test: host sends start-game → room transitions to Submitting, both clients receive `phase-changed`
- [x] New test: non-host player gets "Only the host can start the game" error
- [x] New test: start-game outside Lobby phase gets "Game can only be started from the lobby" error
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)