### PR TITLE
Add graceful player disconnect handling during gameplay

### DIFF
--- a/server/src/roomManager.test.ts
+++ b/server/src/roomManager.test.ts
@@ -1348,5 +1348,237 @@ describe("RoomManager", () => {
       });
     });
   });
+
+  describe("player disconnect during gameplay", () => {
+    /**
+     * Sets up a 4-player room in Playing phase (like setupPlayingRoom in the
+     * turn-engine tests) and returns all websockets plus the room.
+     */
+    function setupGameRoom() {
+      vi.useFakeTimers();
+      const ws1 = mockWs();
+      const ws2 = mockWs();
+      const ws3 = mockWs();
+      const ws4 = mockWs();
+      rm.handleConnection(ws1, "AB12", "Alice"); // host
+      rm.handleConnection(ws2, "AB12", "Bob");
+      rm.handleConnection(ws3, "AB12", "Carol");
+      rm.handleConnection(ws4, "AB12", "Dave");
+
+      const room = rm.getRoom("AB12")!;
+      // Assign teams
+      room.players[0].team = Team.A; // Alice
+      room.players[1].team = Team.A; // Bob
+      room.players[2].team = Team.B; // Carol
+      room.players[3].team = Team.B; // Dave
+
+      // Set up slips and transition to Playing
+      room.phase = GamePhase.Playing;
+      const slips: Slip[] = [
+        { id: "s1", text: "Einstein", submittedBy: room.players[0].id },
+        { id: "s2", text: "Beyoncé", submittedBy: room.players[0].id },
+        { id: "s3", text: "Pikachu", submittedBy: room.players[1].id },
+        { id: "s4", text: "Cleopatra", submittedBy: room.players[1].id },
+        { id: "s5", text: "Mozart", submittedBy: room.players[2].id },
+        { id: "s6", text: "Godzilla", submittedBy: room.players[2].id },
+        { id: "s7", text: "Sherlock", submittedBy: room.players[3].id },
+        { id: "s8", text: "Gandalf", submittedBy: room.players[3].id },
+      ];
+      room.slipPool = [...slips];
+      room.allSlips = [...slips];
+      room.activeTeam = Team.A;
+
+      ws1.send.mockClear();
+      ws2.send.mockClear();
+      ws3.send.mockClear();
+      ws4.send.mockClear();
+
+      return { ws1, ws2, ws3, ws4, room };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe("clue-giver disconnect", () => {
+      it("ends the turn immediately when the active clue-giver disconnects", () => {
+        const { ws1, ws2, ws3, ws4, room } = setupGameRoom();
+
+        // Start a turn — Alice (Team A) is clue-giver
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(room.phase).toBe(GamePhase.TurnActive);
+        expect(room.activeClueGiverId).toBe(room.players[0].id); // Alice
+
+        // Clear mocks before disconnect
+        ws2.send.mockClear();
+        ws3.send.mockClear();
+        ws4.send.mockClear();
+
+        // Disconnect Alice (the clue-giver)
+        rm.handleDisconnect(ws1);
+
+        // Turn should have ended — phase should be TurnEnd (not TurnActive)
+        expect(room.phase).toBe(GamePhase.TurnEnd);
+        // Alice should be marked disconnected, not removed
+        const alice = room.players.find((p) => p.name === "Alice")!;
+        expect(alice.connected).toBe(false);
+      });
+
+      it("awards no additional points when clue-giver disconnects mid-turn", () => {
+        const { ws1, ws2, ws3, ws4, room } = setupGameRoom();
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        const scoreBefore = room.scores[Team.A];
+
+        rm.handleDisconnect(ws1);
+
+        // No additional points awarded
+        expect(room.scores[Team.A]).toBe(scoreBefore);
+      });
+
+      it("clears the turn timer when clue-giver disconnects", () => {
+        const { ws1, room } = setupGameRoom();
+
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(room.phase).toBe(GamePhase.TurnActive);
+
+        rm.handleDisconnect(ws1);
+
+        // Advancing time should not change anything (timer cleared)
+        const phaseAfter = room.phase;
+        vi.advanceTimersByTime(35000);
+        expect(room.phase).toBe(phaseAfter);
+      });
+    });
+
+    describe("host disconnect during gameplay", () => {
+      it("transfers host to another connected player when host disconnects", () => {
+        const { ws1, room } = setupGameRoom();
+
+        expect(room.players[0].isHost).toBe(true); // Alice is host
+        rm.handleDisconnect(ws1);
+
+        const alice = room.players.find((p) => p.name === "Alice")!;
+        expect(alice.isHost).toBe(false);
+        expect(alice.connected).toBe(false);
+
+        // Another connected player should be host
+        const connectedHost = room.players.find((p) => p.isHost && p.connected);
+        expect(connectedHost).toBeDefined();
+      });
+
+      it("preserves disconnected player scores and slips", () => {
+        const { ws1, room } = setupGameRoom();
+
+        // Give Alice some slips
+        const alice = room.players.find((p) => p.name === "Alice")!;
+        alice.slips = [{ id: "test1", text: "Test", submittedBy: alice.id }];
+
+        rm.handleDisconnect(ws1);
+
+        // Alice should still be in the roster with slips preserved
+        const aliceAfter = room.players.find((p) => p.name === "Alice")!;
+        expect(aliceAfter).toBeDefined();
+        expect(aliceAfter.connected).toBe(false);
+        expect(aliceAfter.slips).toHaveLength(1);
+        expect(aliceAfter.team).toBe(Team.A);
+      });
+    });
+
+    describe("team-empty pause", () => {
+      it("pauses the game when a team has no connected players", () => {
+        const { ws3, ws4, room } = setupGameRoom();
+
+        // Disconnect both Team B players (Carol and Dave)
+        rm.handleDisconnect(ws3);
+        rm.handleDisconnect(ws4);
+
+        expect(room.phase).toBe(GamePhase.Paused);
+        expect(room.pausedFromPhase).toBe(GamePhase.Playing);
+      });
+
+      it("broadcasts a game-paused message when team becomes empty", () => {
+        const { ws1, ws3, ws4, room } = setupGameRoom();
+        ws1.send.mockClear();
+
+        rm.handleDisconnect(ws3);
+        rm.handleDisconnect(ws4);
+
+        // Find the game-paused message sent to ws1
+        const messages = ws1.send.mock.calls.map((c: any) => JSON.parse(c[0]));
+        const pausedMsg = messages.find(
+          (m: any) => m.type === ServerMessageType.GamePaused,
+        );
+        expect(pausedMsg).toBeDefined();
+        expect(pausedMsg.reason).toContain("Team B");
+      });
+
+      it("unpauses the game when a player reconnects to the empty team", () => {
+        const { ws3, ws4, room } = setupGameRoom();
+
+        // Disconnect both Team B players
+        rm.handleDisconnect(ws3);
+        rm.handleDisconnect(ws4);
+        expect(room.phase).toBe(GamePhase.Paused);
+
+        // Carol reconnects
+        const ws3b = mockWs();
+        rm.handleConnection(ws3b, "AB12", "Carol");
+
+        expect(room.phase).toBe(GamePhase.Playing);
+        expect(room.pausedFromPhase).toBeNull();
+      });
+
+      it("pauses and ends the turn when clue-giver's entire team disconnects mid-turn", () => {
+        const { ws1, ws2, room } = setupGameRoom();
+
+        // Start a turn — Team A active
+        rm.handleMessage(ws1, { type: ClientMessageType.StartTurn });
+        expect(room.phase).toBe(GamePhase.TurnActive);
+
+        // Disconnect both Team A players (Alice and Bob)
+        rm.handleDisconnect(ws1); // clue-giver disconnect ends turn
+        rm.handleDisconnect(ws2); // team now empty → pause
+
+        expect(room.phase).toBe(GamePhase.Paused);
+        // The turn should have been ended
+        expect(room.activeClueGiverId).toBeNull();
+      });
+    });
+
+    describe("lobby disconnect still removes players", () => {
+      it("removes the player entirely when disconnecting in lobby phase", () => {
+        const ws1 = mockWs();
+        const ws2 = mockWs();
+        rm.handleConnection(ws1, "AB12", "Alice");
+        rm.handleConnection(ws2, "AB12", "Bob");
+
+        rm.handleDisconnect(ws2);
+
+        const room = rm.getRoom("AB12")!;
+        expect(room.players).toHaveLength(1);
+        expect(room.players.find((p) => p.name === "Bob")).toBeUndefined();
+      });
+    });
+
+    describe("reconnection", () => {
+      it("reconnects a disconnected player preserving team and slips", () => {
+        const { ws1, room } = setupGameRoom();
+        const alice = room.players.find((p) => p.name === "Alice")!;
+        const aliceId = alice.id;
+
+        rm.handleDisconnect(ws1);
+        expect(alice.connected).toBe(false);
+
+        // Alice reconnects
+        const ws1b = mockWs();
+        rm.handleConnection(ws1b, "AB12", "Alice");
+
+        expect(alice.connected).toBe(true);
+        expect(alice.id).toBe(aliceId); // same player record
+        expect(alice.team).toBe(Team.A);
+      });
+    });
+  });
 });
 

--- a/server/src/roomManager.ts
+++ b/server/src/roomManager.ts
@@ -56,6 +56,7 @@ function makeDefaultRoom(code: string): Room {
     turnSkipped: [],
     allSlips: [],
     carryoverTime: 0,
+    pausedFromPhase: null,
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
   };
@@ -112,7 +113,32 @@ export class RoomManager {
       return "Room is full (maximum 8 players)";
     }
 
-    // Check for duplicate name in the room
+    // Check for a disconnected player with the same name (reconnection)
+    const disconnectedPlayer = room!.players.find(
+      (p) => p.name.toLowerCase() === trimmedName.toLowerCase() && !p.connected
+    );
+
+    if (disconnectedPlayer) {
+      // Reconnect: restore the existing player record
+      disconnectedPlayer.connected = true;
+      room!.lastActivityAt = Date.now();
+
+      this.clients.set(disconnectedPlayer.id, { ws, playerId: disconnectedPlayer.id, roomCode });
+
+      // Transfer host if no one else is host
+      const hasHost = room!.players.some((p) => p.isHost && p.connected);
+      if (!hasHost) {
+        disconnectedPlayer.isHost = true;
+      }
+
+      // Check if we can unpause
+      this.checkTeamPause(room!);
+
+      this.broadcastRoomState(roomCode);
+      return null;
+    }
+
+    // Check for duplicate name among connected players
     const nameTaken = room!.players.some(
       (p) => p.name.toLowerCase() === trimmedName.toLowerCase() && p.connected
     );
@@ -127,7 +153,7 @@ export class RoomManager {
       id: playerId,
       name: trimmedName,
       team: null,
-      isHost: isNewRoom || room!.players.length === 0,
+      isHost: isNewRoom || room!.players.filter((p) => p.connected).length === 0,
       connected: true,
       slips: [],
     };
@@ -154,7 +180,11 @@ export class RoomManager {
 
   /**
    * Handle a player disconnecting.
-   * Removes them from the room, transfers host if needed.
+   * In lobby phase, removes the player entirely.
+   * During gameplay, marks them as disconnected (preserving scores/slips).
+   * Ends the turn if the active clue-giver disconnects.
+   * Transfers host if the host disconnects.
+   * Pauses the game if a team has no connected players.
    */
   handleDisconnect(ws: WebSocket): void {
     const clientEntry = this.findClientByWs(ws);
@@ -167,31 +197,109 @@ export class RoomManager {
       return;
     }
 
-    // Remove the player from the room
-    const playerIndex = room.players.findIndex((p) => p.id === playerId);
-    if (playerIndex === -1) {
+    const player = room.players.find((p) => p.id === playerId);
+    if (!player) {
       this.clients.delete(playerId);
       return;
     }
 
-    const wasHost = room.players[playerIndex].isHost;
-    room.players.splice(playerIndex, 1);
+    const wasHost = player.isHost;
+    const wasClueGiver = room.activeClueGiverId === playerId;
     this.clients.delete(playerId);
     room.lastActivityAt = Date.now();
 
-    // If room is empty, remove it
-    if (room.players.length === 0) {
+    // In lobby phase, remove the player entirely
+    if (room.phase === GamePhase.Lobby) {
+      const playerIndex = room.players.findIndex((p) => p.id === playerId);
+      room.players.splice(playerIndex, 1);
+
+      if (room.players.length === 0) {
+        this.rooms.delete(roomCode);
+        return;
+      }
+
+      if (wasHost) {
+        room.players[0].isHost = true;
+      }
+
+      this.broadcastRoomState(roomCode);
+      return;
+    }
+
+    // During gameplay: mark as disconnected instead of removing
+    player.connected = false;
+    player.isHost = false;
+
+    // Check if any connected players remain at all
+    const connectedPlayers = room.players.filter((p) => p.connected);
+    if (connectedPlayers.length === 0) {
+      this.clearTurnTimer(roomCode);
       this.rooms.delete(roomCode);
       return;
     }
 
-    // Transfer host if the host left
+    // Transfer host to another connected player
     if (wasHost) {
-      room.players[0].isHost = true;
+      connectedPlayers[0].isHost = true;
     }
 
-    // Broadcast updated state
+    // If the active clue-giver disconnected during a turn, end the turn immediately
+    if (wasClueGiver && room.phase === GamePhase.TurnActive) {
+      this.endTurn(room);
+    }
+
+    // Check if either team has no connected players → pause the game
+    this.checkTeamPause(room);
+
     this.broadcastRoomState(roomCode);
+  }
+
+  /**
+   * Check if any team has no connected players during gameplay.
+   * If so, pause the game. If teams are restored, unpause.
+   */
+  private checkTeamPause(room: Room): void {
+    // Only check during active gameplay phases
+    const gameplayPhases = [
+      GamePhase.Playing,
+      GamePhase.TurnActive,
+      GamePhase.TurnEnd,
+      GamePhase.RoundEnd,
+    ];
+
+    if (room.phase === GamePhase.Paused) {
+      // Check if we can unpause — both teams need connected players
+      const teamAConnected = room.players.filter((p) => p.team === Team.A && p.connected);
+      const teamBConnected = room.players.filter((p) => p.team === Team.B && p.connected);
+
+      if (teamAConnected.length > 0 && teamBConnected.length > 0 && room.pausedFromPhase) {
+        room.phase = room.pausedFromPhase;
+        room.pausedFromPhase = null;
+        this.broadcastPhaseChanged(room);
+      }
+      return;
+    }
+
+    if (!gameplayPhases.includes(room.phase)) return;
+
+    const teamAConnected = room.players.filter((p) => p.team === Team.A && p.connected);
+    const teamBConnected = room.players.filter((p) => p.team === Team.B && p.connected);
+
+    if (teamAConnected.length === 0 || teamBConnected.length === 0) {
+      // If a turn is active, end it first
+      if (room.phase === GamePhase.TurnActive) {
+        this.endTurn(room);
+      }
+
+      room.pausedFromPhase = room.phase;
+      room.phase = GamePhase.Paused;
+
+      const emptyTeam = teamAConnected.length === 0 ? "A" : "B";
+      this.broadcastToRoom(room.code, {
+        type: ServerMessageType.GamePaused,
+        reason: `Team ${emptyTeam} has no connected players`,
+      });
+    }
   }
 
   /**
@@ -246,8 +354,8 @@ export class RoomManager {
   private handleRandomizeTeams(room: Room, sender: Player): string | null {
     if (!sender.isHost) return "Only the host can randomize teams";
 
-    // Shuffle players array copy using Fisher-Yates
-    const shuffled = [...room.players];
+    // Shuffle connected players using Fisher-Yates
+    const shuffled = room.players.filter((p) => p.connected);
     for (let i = shuffled.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
@@ -319,8 +427,10 @@ export class RoomManager {
     // Broadcast updated room state so all clients see slip submission progress
     this.broadcastRoomState(room.code);
 
-    // Check if all players have submitted — transition to playing
-    const allSubmitted = room.players.every((p) => p.slips.length === 4);
+    // Check if all connected players have submitted — transition to playing
+    const allSubmitted = room.players
+      .filter((p) => p.connected)
+      .every((p) => p.slips.length === 4);
     if (allSubmitted) {
       room.phase = GamePhase.Playing;
 
@@ -350,9 +460,9 @@ export class RoomManager {
     }
     if (room.slipPool.length === 0) return "No slips in the pool";
 
-    // Determine clue-giver from the active team
-    const teamPlayers = room.players.filter((p) => p.team === room.activeTeam);
-    if (teamPlayers.length === 0) return "No players on the active team";
+    // Determine clue-giver from connected players on the active team
+    const teamPlayers = room.players.filter((p) => p.team === room.activeTeam && p.connected);
+    if (teamPlayers.length === 0) return "No connected players on the active team";
 
     const clueGiverIdx = room.clueGiverIndex[room.activeTeam] % teamPlayers.length;
     const clueGiver = teamPlayers[clueGiverIdx];
@@ -486,6 +596,7 @@ export class RoomManager {
     room.turnGuessed = [];
     room.turnSkipped = [];
     room.carryoverTime = 0;
+    room.pausedFromPhase = null;
 
     // Clear player slips so they can submit new ones
     for (const p of room.players) {
@@ -621,9 +732,9 @@ export class RoomManager {
       // Normal turn end — pool still has slips
       room.phase = GamePhase.TurnEnd;
 
-      // Advance clue-giver index for the active team
+      // Advance clue-giver index for the active team (connected players only)
       const teamPlayers = room.players.filter(
-        (p) => p.team === room.activeTeam,
+        (p) => p.team === room.activeTeam && p.connected,
       );
       if (teamPlayers.length > 0) {
         room.clueGiverIndex[room.activeTeam] =

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -27,6 +27,8 @@ export enum GamePhase {
   RoundEnd = "round-end",
   /** Game over, showing final scores */
   GameOver = "game-over",
+  /** Game paused because a team has no connected players */
+  Paused = "paused",
 }
 
 /** A slip of paper with a name on it */
@@ -75,6 +77,8 @@ export interface Room {
   allSlips: Slip[];
   /** Seconds carried over from the previous round's last turn */
   carryoverTime: number;
+  /** Phase the game was in before pausing (null when not paused) */
+  pausedFromPhase: GamePhase | null;
   createdAt: number;
   lastActivityAt: number;
 }
@@ -189,6 +193,8 @@ export enum ServerMessageType {
   GameOver = "game-over",
   /** Room was created (sent to the host) */
   RoomCreated = "room-created",
+  /** Game paused because a team has no connected players */
+  GamePaused = "game-paused",
 }
 
 /** Sanitized room state sent to clients (hides slip text when appropriate) */
@@ -275,6 +281,11 @@ export interface RoomCreatedMessage {
   roomId: string;
 }
 
+export interface GamePausedMessage {
+  type: ServerMessageType.GamePaused;
+  reason: string;
+}
+
 export type ServerMessage =
   | RoomStateMessage
   | ErrorMessage
@@ -289,4 +300,5 @@ export type ServerMessage =
   | TurnEndedMessage
   | RoundEndedMessage
   | GameOverMessage
-  | RoomCreatedMessage;
+  | RoomCreatedMessage
+  | GamePausedMessage;


### PR DESCRIPTION
## Summary
- Players who disconnect during active gameplay are marked as disconnected (not removed), preserving their scores, slips, and team assignment
- If the active clue-giver disconnects mid-turn, the turn ends immediately with no additional points awarded
- Host role automatically transfers to another connected player when the host disconnects
- Game pauses with a broadcast notification when a team has no connected players; unpauses when a player reconnects
- Disconnected players can reconnect by joining with the same name, restoring their original player record
- In lobby phase, disconnect still removes the player entirely (no state to preserve)

Closes #30

## Test plan
- [x] Clue-giver disconnect ends the turn immediately (no extra points)
- [x] Turn timer is cleared on clue-giver disconnect
- [x] Host transfer works on host disconnect during gameplay
- [x] Disconnected player scores and slips are preserved in roster
- [x] Game pauses when a team has no connected players
- [x] Game-paused message is broadcast with team info
- [x] Game unpauses when a player reconnects to the empty team
- [x] Turn ends + game pauses when entire active team disconnects mid-turn
- [x] Lobby disconnect still removes players entirely
- [x] Reconnection restores the original player record (same ID, team, slips)
- [x] All 151 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)