### PR TITLE
feat: support custom ports via .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tsbuildinfo
+.env

--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ All ports are configurable via environment variables. The defaults are **3000** 
 | `VITE_SERVER_PORT` | `3000` | Tells the client which port the game server is on |
 | `VITE_CLIENT_PORT` | `5173` | Vite dev server port |
 
+**Using `.env` files (recommended):**
+
+Copy the example files and edit as needed:
+
+```bash
+cp server/.env.example server/.env
+cp client/.env.example client/.env
+```
+
+`server/.env`:
+```
+PORT=4000
+```
+
+`client/.env`:
+```
+VITE_SERVER_PORT=4000
+VITE_CLIENT_PORT=8080
+```
+
+The server loads `server/.env` automatically on startup. The client loads `client/.env` automatically via Vite.
+
+**Using inline environment variables:**
+
 When changing the server port, set both `PORT` and `VITE_SERVER_PORT` so the client knows where to connect:
 
 ```bash

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Vite dev server port (default: 5173)
+VITE_CLIENT_PORT=5173
+
+# Game server port — must match PORT in server/.env (default: 3000)
+VITE_SERVER_PORT=3000

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+# Game server port (default: 3000)
+PORT=3000

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/websocket": "^11.0.0",
+        "dotenv": "^17.3.1",
         "fastify": "^5.2.0",
         "uuid": "^13.0.0",
         "ws": "^8.18.0"
@@ -1237,6 +1238,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexify": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fastify/websocket": "^11.0.0",
+    "dotenv": "^17.3.1",
     "fastify": "^5.2.0",
     "uuid": "^13.0.0",
     "ws": "^8.18.0"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import Fastify from "fastify";
 import websocket from "@fastify/websocket";
 import { RoomManager } from "./roomManager.js";


### PR DESCRIPTION
## Summary

- Add `dotenv` to the server so `PORT` can be set from `server/.env` without inline env vars
- Add `server/.env.example` and `client/.env.example` with documented variables
- Client already supports `.env` natively via Vite — no code changes needed there
- Update README with `.env`-based setup instructions alongside the existing inline approach
- Add `.env` to `.gitignore`

## Test plan

- [ ] Copy `server/.env.example` to `server/.env`, set `PORT=4000`, run `npm run dev:server` — server should bind to 4000
- [ ] Copy `client/.env.example` to `client/.env`, set `VITE_CLIENT_PORT=8080` and `VITE_SERVER_PORT=4000`, run `npm run dev:client` — Vite should start on 8080 and client should connect to server on 4000
- [ ] Without `.env` files present, defaults (3000 / 5173) should still apply

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)