### PR TITLE
fix: auto-install server deps before dev:server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:shared": "cd shared && npx tsc",
     "build:server": "cd server && npx tsc",
     "build:client": "cd client && npx vite build",
+    "predev:server": "cd server && npm install",
     "dev:server": "cd server && npx tsx src/index.ts",
     "dev:client": "cd client && npx vite",
     "install:all": "cd shared && npm install && cd ../server && npm install && cd ../client && npm install"


### PR DESCRIPTION
## Summary
- Adds a `predev:server` npm lifecycle hook that automatically runs `npm install` in the `server/` directory before starting the dev server
- Fixes `ERR_MODULE_NOT_FOUND: Cannot find package 'dotenv'` for users who haven't installed server dependencies after a fresh clone or after new deps were added

## Root Cause
The `dotenv` package was added to `server/package.json` in #39 but users running `npm run dev:server` without first running `npm run install:all` would hit a missing package error. npm's built-in lifecycle hooks (`predev:server`) ensure deps are always present before the server starts.

## Test plan
- [ ] Clone repo fresh, run `npm run dev:server` — should succeed without requiring manual `npm run install:all` first
- [ ] Verify dotenv loads correctly (server respects `PORT` env var from `.env`)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)